### PR TITLE
feat: Add integration tests environment

### DIFF
--- a/test/SPX-WEBAPI.Tests/IntegrationTests/Config/IntegrationTestsFixture.cs
+++ b/test/SPX-WEBAPI.Tests/IntegrationTests/Config/IntegrationTestsFixture.cs
@@ -1,11 +1,6 @@
-﻿using Microsoft.AspNetCore.Authentication;
-using Microsoft.AspNetCore.Authentication.OAuth;
-using Microsoft.AspNetCore.Authorization;
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc.Testing;
-using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.DependencyInjection;
 using SPX_WEBAPI.AuthorizationAndAuthentication;
-using SPX_WEBAPI.Domain.Models;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using Xunit;
@@ -32,39 +27,26 @@ namespace SPX_WEBAPI.Tests.IntegrationTests.Config
             };
 
             Factory = new WebApiApplicationFactory<TStartup>();
-
-
             Client = Factory.CreateClient(clientOptions);
 
-            //var userData = new Authenticate
-            //{
-            //    Login = "usuario",
-            //    Password = "m1nh@s3nh@"
-            //};
-
-            //Client = Factory.WithWebHostBuilder(builder =>
-            //{
-            //    builder.ConfigureTestServices(services => services.AddScoped(_ => userData));
-            //}).CreateClient(clientOptions);
-
-            Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Test");
+            //Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(JwtBearerDefaults.AuthenticationScheme);
         }
 
-        public async Task AuthenticateLoginApi()
-        {
-            var userData = new Authenticate
-            {
-                Login = "usuario",
-                Password = "m1nh@s3nh@"
-            };
+        //public async Task AuthenticateLoginApi()
+        //{
+        //    var userData = new Authenticate
+        //    {
+        //        Login = "usuario",
+        //        Password = "m1nh@s3nh@"
+        //    };
 
-            // Recreating client to avoid web config
-            Client = Factory.CreateClient();
+        //    // Recreating client to avoid web config
+        //    Client = Factory.CreateClient();
 
-            var response = await Client.PostAsJsonAsync("/Login", userData);
-            response.EnsureSuccessStatusCode();
-            UserToken = await response.Content.ReadAsStringAsync();
-        }
+        //    var response = await Client.PostAsJsonAsync("/Login", userData);
+        //    response.EnsureSuccessStatusCode();
+        //    UserToken = await response.Content.ReadAsStringAsync();
+        //}
 
         public void Dispose()
         {

--- a/test/SPX-WEBAPI.Tests/IntegrationTests/Config/TestAuthHandler.cs
+++ b/test/SPX-WEBAPI.Tests/IntegrationTests/Config/TestAuthHandler.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
-using SPX_WEBAPI.Domain.Models;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 
@@ -26,9 +26,9 @@ namespace SPX_WEBAPI.Tests.IntegrationTests.Config
             if (_mockAuthUser.Claims.Count == 0)
                 return Task.FromResult(AuthenticateResult.Fail("Mock auth user not configured."));
 
-            var identity = new ClaimsIdentity(_mockAuthUser.Claims, "Test");
+            var identity = new ClaimsIdentity(_mockAuthUser.Claims, JwtBearerDefaults.AuthenticationScheme);
             var principal = new ClaimsPrincipal(identity);
-            var ticket = new AuthenticationTicket(principal, "Test");
+            var ticket = new AuthenticationTicket(principal, JwtBearerDefaults.AuthenticationScheme);
 
             var result = AuthenticateResult.Success(ticket);
 

--- a/test/SPX-WEBAPI.Tests/IntegrationTests/Config/TestsExtensions.cs
+++ b/test/SPX-WEBAPI.Tests/IntegrationTests/Config/TestsExtensions.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 
 namespace SPX_WEBAPI.Tests.IntegrationTests.Config
 {
@@ -29,16 +30,16 @@ namespace SPX_WEBAPI.Tests.IntegrationTests.Config
         {
             services.AddAuthorization(options =>
             {
-                // AuthConstants.Scheme is just a scheme we define. I called it "TestAuth"
-                options.DefaultPolicy = new AuthorizationPolicyBuilder("Test")
-                .RequireAuthenticatedUser()
+                options.DefaultPolicy = new AuthorizationPolicyBuilder()
+                    .AddAuthenticationSchemes(JwtBearerDefaults.AuthenticationScheme)
+                    .RequireAuthenticatedUser()
                     .Build();
             });
 
             // Register our custom authentication handler
-            return services.AddAuthentication("Test")
+            return services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
                 .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>(
-                    "Test", options => { });
+                    JwtBearerDefaults.AuthenticationScheme, options => { });
         }
     }
 }

--- a/test/SPX-WEBAPI.Tests/IntegrationTests/Config/WebApiApplicationFactory.cs
+++ b/test/SPX-WEBAPI.Tests/IntegrationTests/Config/WebApiApplicationFactory.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using SPX_WEBAPI.Infra.Data;
 using System.Security.Claims;
@@ -23,13 +24,7 @@ namespace SPX_WEBAPI.Tests.IntegrationTests.Config
 
             builder.ConfigureServices(services =>
             {
-                var descriptor = services.SingleOrDefault(
-                    d => d.ServiceType ==
-                        typeof(DbContextOptions<ApplicationDbContext>));
-
-                services.Remove(descriptor);
-                
-                //services.RemoveAll(typeof(DbContextOptions<ApplicationDbContext>));
+                services.RemoveAll(typeof(DbContextOptions<ApplicationDbContext>));
 
                 services.AddDbContext<ApplicationDbContext>(options =>
                     options.UseInMemoryDatabase("SpxWebApiDatabase"));


### PR DESCRIPTION
Authorization Mock is working now. 

Try to develop a way to do test integration without mocking authorization. See AuthenticateLoginApi() method and try to authenticate through bearer token on header.